### PR TITLE
Bugfix: Send OFPT_ERROR, not OFPT_FEATURES_REQUEST

### DIFF
--- a/fluid/OFServer.cc
+++ b/fluid/OFServer.cc
@@ -106,7 +106,7 @@ void OFServer::base_message_callback(BaseOFConnection* c, void* data, size_t len
         else {
             struct ofp_error_msg msg;
             msg.header.version = version;
-            msg.header.type = OFPT_FEATURES_REQUEST;
+            msg.header.type = OFPT_ERROR;
             msg.header.length = htons(12);
             msg.header.xid = ((uint32_t*) data)[1];
             msg.type = htons(OFPET_HELLO_FAILED);


### PR DESCRIPTION
Send OFPT_ERROR (with type field of OFPET_HELLO_FAILED,
and code field of OFPHFC_INCOMPATIBLE) for error when
version negotiation fails, not OFPT_FEATURES_REQUEST.
