### PR TITLE
OFClient into libfluid_base, switch vs controller independence

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,9 +11,11 @@ lib_LTLIBRARIES = libfluid_base.la
 libfluid_base_la_SOURCES = fluid/base/EventLoop.hh fluid/base/EventLoop.cc\
 						   fluid/base/BaseOFConnection.hh fluid/base/BaseOFConnection.cc\
 						   fluid/base/BaseOFServer.hh fluid/base/BaseOFServer.cc\
+						   fluid/base/BaseOFClient.hh fluid/base/BaseOFClient.cc\
 						   fluid/OFConnection.hh fluid/OFConnection.cc\
 						   fluid/OFServerSettings.hh fluid/OFServerSettings.cc\
 						   fluid/OFServer.hh fluid/OFServer.cc fluid/base/of.hh\
+							 fluid/OFClient.hh fluid/OFClient.cc\
 						   fluid/TLS.hh fluid/TLS.cc
 libfluid_base_la_LIBADD = $(libevent_core_LIBS) $(libevent_pthreads_LIBS)
 if TLS
@@ -24,9 +26,11 @@ libfluid_base_includedir = $(includedir)
 nobase_libfluid_base_include_HEADERS = fluid/base/EventLoop.hh\
 							   		   fluid/base/BaseOFConnection.hh\
 							   		   fluid/base/BaseOFServer.hh\
+							   		   fluid/base/BaseOFClient.hh\
 							   		   fluid/OFConnection.hh\
 							   		   fluid/OFServerSettings.hh\
 							   		   fluid/OFServer.hh\
+							   		   fluid/OFClient.hh\
 							   		   fluid/TLS.hh
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/fluid/OFClient.cc
+++ b/fluid/OFClient.cc
@@ -1,0 +1,141 @@
+#include "OFClient.hh"
+#include <fluid/of10msg.hh>
+
+using namespace fluid_base;
+using namespace fluid_msg;
+
+void OFClient::base_message_callback(BaseOFConnection* c, void* data, size_t len) {
+    uint8_t type = ((uint8_t*) data)[1];
+    OFConnection* cc = (OFConnection*) c->get_manager();
+
+    // We trust that the other end is using the negotiated protocol
+    // version. Should we?
+
+    if (ofsc.liveness_check() and type == of10::OFPT_ECHO_REQUEST) {
+        uint8_t msg[8];
+        memset((void*) msg, 0, 8);
+        msg[0] = ((uint8_t*) data)[0];
+        msg[1] = of10::OFPT_ECHO_REPLY;
+        ((uint16_t*) msg)[1] = htons(8);
+        ((uint32_t*) msg)[1] = ((uint32_t*) data)[1];
+        // TODO: copy echo data
+        c->send(msg, 8);
+
+        if (ofsc.dispatch_all_messages()) goto dispatch; else goto done;
+    }
+
+    if (ofsc.handshake() and type == of10::OFPT_HELLO) {
+        uint8_t version = ((uint8_t*) data)[0];
+        if (not this->ofsc.supported_versions() & (1 << (version - 1))) {
+            uint8_t msg[12];
+            memset((void*) msg, 0, 8);
+            msg[0] = version;
+            msg[1] = of10::OFPT_ERROR;
+            ((uint16_t*) msg)[1] = htons(12);
+            ((uint32_t*) msg)[1] = ((uint32_t*) data)[1];
+            ((uint16_t*) msg)[4] = htons(of10::OFPET_HELLO_FAILED);
+            ((uint16_t*) msg)[5] = htons(of10::OFPHFC_INCOMPATIBLE);
+            cc->send(msg, 12);
+            cc->close();
+            cc->set_state(OFConnection::STATE_FAILED);
+            connection_callback(cc, OFConnection::EVENT_FAILED_NEGOTIATION);
+        }
+
+        if (ofsc.dispatch_all_messages()) goto dispatch; else goto done;
+    }
+
+    if (ofsc.liveness_check() and type == of10::OFPT_ECHO_REPLY) {
+        if (ntohl(((uint32_t*) data)[1]) == ECHO_XID) {
+            cc->set_alive(true);
+        }
+
+        if (ofsc.dispatch_all_messages()) goto dispatch; else goto done;
+    }
+
+    if (ofsc.handshake() and type == of10::OFPT_FEATURES_REQUEST) {
+        cc->set_version(((uint8_t*) data)[0]);
+        cc->set_state(OFConnection::STATE_RUNNING);
+        of10::FeaturesRequest freq;
+        freq.unpack((uint8_t*) data);
+        of10::FeaturesReply fr(freq.xid(), this->datapath_id, 1, 1, 0x0, 0x0);
+        uint8_t *buffer =  fr.pack();
+        c->send(buffer, fr.length());
+        OFMsg::free_buffer(buffer);
+
+        if (ofsc.liveness_check())
+            c->add_timed_callback(send_echo, ofsc.echo_interval() * 1000, cc);
+        connection_callback(cc, OFConnection::EVENT_ESTABLISHED);
+
+        goto dispatch;
+    }
+
+    goto dispatch;
+
+    // Dispatch a message and goto done
+    dispatch:
+        message_callback(cc, type, data, len);
+        goto done;
+    // Free the message and return
+    done:
+        c->free_data(data);
+        return;
+}
+
+void OFClient::base_connection_callback(BaseOFConnection* c, BaseOFConnection::Event event_type) {
+    /* If the connection was closed, destroy it.
+    There's no need to notify the user, since a DOWN event already
+    means a CLOSED event will happen and nothing should be expected from
+    the connection. */
+    if (event_type == BaseOFConnection::EVENT_CLOSED) {
+        BaseOFClient::base_connection_callback(c, event_type);
+        // TODO: delete the OFConnection?
+        return;
+    }
+
+    int conn_id = c->get_id();
+    if (event_type == BaseOFConnection::EVENT_UP) {
+        if (ofsc.handshake()) {
+            struct of10::ofp_hello msg;
+            msg.header.version = this->ofsc.max_supported_version();
+            msg.header.type = of10::OFPT_HELLO;
+            msg.header.length = htons(8);
+            msg.header.xid = htonl(HELLO_XID);
+            c->send(&msg, 8);
+        }
+
+		this->conn = new OFConnection(c, this);
+        connection_callback(this->conn, OFConnection::EVENT_STARTED);
+    }
+    else if (event_type == BaseOFConnection::EVENT_DOWN) {
+        connection_callback(this->conn, OFConnection::EVENT_CLOSED);
+    }
+}
+
+void OFClient::free_data(void* data) {
+    BaseOFClient::free_data(data);
+}
+
+void* OFClient::send_echo(void* arg) {
+    OFConnection* cc = static_cast<OFConnection*>(arg);
+
+    if (!cc->is_alive()) {
+        cc->close();
+        cc->get_ofhandler()->connection_callback(cc, OFConnection::EVENT_DEAD);
+        return NULL;
+    }
+
+    uint8_t msg[8];
+    memset((void*) msg, 0, 8);
+    msg[0] = (uint8_t) cc->get_version();
+    msg[1] = of10::OFPT_ECHO_REQUEST;
+    ((uint16_t*) msg)[1] = htons(8);
+    ((uint32_t*) msg)[1] = htonl(ECHO_XID);
+
+    cc->set_alive(false);
+    cc->send(msg, 8);
+
+    return NULL;
+}
+
+
+

--- a/fluid/OFClient.cc
+++ b/fluid/OFClient.cc
@@ -1,8 +1,38 @@
 #include "OFClient.hh"
-#include <fluid/of10msg.hh>
+#include "fluid/base/of.hh"
 
-using namespace fluid_base;
-using namespace fluid_msg;
+namespace fluid_base {
+
+OFClient::OFClient(int id, std::string address, int port,
+             const struct OFServerSettings ofsc) :
+        BaseOFClient(id, address, port) {
+    this->ofsc = ofsc;
+    this->conn = NULL;
+}
+
+OFClient::~OFClient() {
+    if (conn != NULL)
+        delete conn;
+}
+
+bool OFClient::start(bool block) {
+    return BaseOFClient::start(block);
+}
+
+
+void OFClient::start_conn(){
+    BaseOFClient::start_conn();
+}
+
+void OFClient::stop_conn(){
+    if (conn != NULL)
+        conn->close();
+}
+
+void OFClient::stop() {
+    stop_conn();
+    BaseOFClient::stop();
+}
 
 void OFClient::base_message_callback(BaseOFConnection* c, void* data, size_t len) {
     uint8_t type = ((uint8_t*) data)[1];
@@ -11,11 +41,11 @@ void OFClient::base_message_callback(BaseOFConnection* c, void* data, size_t len
     // We trust that the other end is using the negotiated protocol
     // version. Should we?
 
-    if (ofsc.liveness_check() and type == of10::OFPT_ECHO_REQUEST) {
+    if (ofsc.liveness_check() and type == OFPT_ECHO_REQUEST) {
         uint8_t msg[8];
         memset((void*) msg, 0, 8);
         msg[0] = ((uint8_t*) data)[0];
-        msg[1] = of10::OFPT_ECHO_REPLY;
+        msg[1] = OFPT_ECHO_REPLY;
         ((uint16_t*) msg)[1] = htons(8);
         ((uint32_t*) msg)[1] = ((uint32_t*) data)[1];
         // TODO: copy echo data
@@ -24,27 +54,36 @@ void OFClient::base_message_callback(BaseOFConnection* c, void* data, size_t len
         if (ofsc.dispatch_all_messages()) goto dispatch; else goto done;
     }
 
-    if (ofsc.handshake() and type == of10::OFPT_HELLO) {
+    if (ofsc.handshake() and type == OFPT_HELLO) {
         uint8_t version = ((uint8_t*) data)[0];
         if (not this->ofsc.supported_versions() & (1 << (version - 1))) {
             uint8_t msg[12];
             memset((void*) msg, 0, 8);
             msg[0] = version;
-            msg[1] = of10::OFPT_ERROR;
+            msg[1] = OFPT_ERROR;
             ((uint16_t*) msg)[1] = htons(12);
             ((uint32_t*) msg)[1] = ((uint32_t*) data)[1];
-            ((uint16_t*) msg)[4] = htons(of10::OFPET_HELLO_FAILED);
-            ((uint16_t*) msg)[5] = htons(of10::OFPHFC_INCOMPATIBLE);
+            ((uint16_t*) msg)[4] = htons(OFPET_HELLO_FAILED);
+            ((uint16_t*) msg)[5] = htons(OFPHFC_INCOMPATIBLE);
             cc->send(msg, 12);
             cc->close();
             cc->set_state(OFConnection::STATE_FAILED);
             connection_callback(cc, OFConnection::EVENT_FAILED_NEGOTIATION);
+        } else {
+            if (ofsc.is_controller()) {
+                struct ofp_header msg;
+                msg.version = ((uint8_t*) data)[0];
+                msg.type = OFPT_FEATURES_REQUEST;
+                msg.length = htons(8);
+                msg.xid = ((uint32_t*) data)[1];
+                c->send(&msg, 8);
+            }
         }
 
         if (ofsc.dispatch_all_messages()) goto dispatch; else goto done;
     }
 
-    if (ofsc.liveness_check() and type == of10::OFPT_ECHO_REPLY) {
+    if (ofsc.liveness_check() and type == OFPT_ECHO_REPLY) {
         if (ntohl(((uint32_t*) data)[1]) == ECHO_XID) {
             cc->set_alive(true);
         }
@@ -52,22 +91,39 @@ void OFClient::base_message_callback(BaseOFConnection* c, void* data, size_t len
         if (ofsc.dispatch_all_messages()) goto dispatch; else goto done;
     }
 
-    if (ofsc.handshake() and type == of10::OFPT_FEATURES_REQUEST) {
+    if (ofsc.handshake() and !ofsc.is_controller() and type == OFPT_FEATURES_REQUEST) {
+        struct ofp_switch_features reply;
+
         cc->set_version(((uint8_t*) data)[0]);
         cc->set_state(OFConnection::STATE_RUNNING);
-        of10::FeaturesRequest freq;
-        freq.unpack((uint8_t*) data);
-        of10::FeaturesReply fr(freq.xid(), this->datapath_id, 1, 1, 0x0, 0x0);
-        uint8_t *buffer =  fr.pack();
-        c->send(buffer, fr.length());
-        OFMsg::free_buffer(buffer);
+        reply.header.version = ((uint8_t*) data)[0];
+        reply.header.type = OFPT_FEATURES_REPLY;
+        reply.header.length = htons(sizeof(reply));
+        reply.header.xid = ((uint32_t*) data)[1];
+        reply.datapath_id = ofsc.datapath_id();
+        reply.n_buffers = ofsc.n_buffers();
+        reply.n_tables = ofsc.n_tables();
+        reply.auxiliary_id = ofsc.auxiliary_id();
+        reply.capabilities = ofsc.capabilities();
+        cc->send(&reply, sizeof(reply));
 
         if (ofsc.liveness_check())
             c->add_timed_callback(send_echo, ofsc.echo_interval() * 1000, cc);
         connection_callback(cc, OFConnection::EVENT_ESTABLISHED);
 
+        if (ofsc.dispatch_all_messages()) goto dispatch; else goto done;
+    }
+
+    // Handle feature replies
+    if (ofsc.handshake() and ofsc.is_controller() and type == OFPT_FEATURES_REPLY) {
+        cc->set_version(((uint8_t*) data)[0]);
+        cc->set_state(OFConnection::STATE_RUNNING);
+        if (ofsc.liveness_check())
+            c->add_timed_callback(send_echo, ofsc.echo_interval() * 1000, cc);
+        connection_callback(cc, OFConnection::EVENT_ESTABLISHED);
         goto dispatch;
     }
+
 
     goto dispatch;
 
@@ -95,9 +151,9 @@ void OFClient::base_connection_callback(BaseOFConnection* c, BaseOFConnection::E
     int conn_id = c->get_id();
     if (event_type == BaseOFConnection::EVENT_UP) {
         if (ofsc.handshake()) {
-            struct of10::ofp_hello msg;
+            struct ofp_hello msg;
             msg.header.version = this->ofsc.max_supported_version();
-            msg.header.type = of10::OFPT_HELLO;
+            msg.header.type = OFPT_HELLO;
             msg.header.length = htons(8);
             msg.header.xid = htonl(HELLO_XID);
             c->send(&msg, 8);
@@ -127,7 +183,7 @@ void* OFClient::send_echo(void* arg) {
     uint8_t msg[8];
     memset((void*) msg, 0, 8);
     msg[0] = (uint8_t) cc->get_version();
-    msg[1] = of10::OFPT_ECHO_REQUEST;
+    msg[1] = OFPT_ECHO_REQUEST;
     ((uint16_t*) msg)[1] = htons(8);
     ((uint32_t*) msg)[1] = htonl(ECHO_XID);
 
@@ -138,4 +194,5 @@ void* OFClient::send_echo(void* arg) {
 }
 
 
+}
 

--- a/fluid/OFClient.hh
+++ b/fluid/OFClient.hh
@@ -1,0 +1,75 @@
+#include <event2/event.h>
+#include <event2/bufferevent.h>
+#include <fluid/base/BaseOFConnection.hh>
+
+#include <stdio.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <string>
+
+#include <string.h>
+#include <arpa/inet.h>
+
+#include <fluid/base/BaseOFConnection.hh>
+#include <fluid/OFConnection.hh>
+#include <fluid/OFServer.hh>
+
+#include "base/BaseOFClient.hh"
+
+using namespace fluid_base;
+
+
+
+class OFClient : private BaseOFClient, public OFHandler {
+public:
+    OFClient(int id, std::string address, int port, uint64_t datapath_id,
+             const struct OFServerSettings ofsc = OFServerSettings().supported_version(0x01).supported_version(0x04)) :
+        BaseOFClient(id, address, port) {
+        this->ofsc = ofsc;
+        this->datapath_id = datapath_id;
+        this->conn = NULL;
+    }
+
+    virtual ~OFClient() {
+        if (conn != NULL)
+            delete conn;
+    }
+
+    virtual bool start(bool block = false) {        
+        return BaseOFClient::start(block);
+    }
+
+    virtual void start_conn(){
+        BaseOFClient::start_conn();
+    }
+
+    virtual void stop_conn(){
+        if (conn != NULL)
+            conn->close();        
+    }
+
+    virtual void stop() {
+        stop_conn();
+        BaseOFClient::stop();
+    }
+
+    // Implement your logic here
+    virtual void connection_callback(OFConnection* conn, OFConnection::Event event_type) {};
+    virtual void message_callback(OFConnection* conn, uint8_t type, void* data, size_t len) {};
+    
+    void free_data(void* data);    
+
+protected:
+    OFConnection* conn;
+    uint64_t datapath_id;    
+
+private:
+    OFServerSettings ofsc;
+    void base_message_callback(BaseOFConnection* c, void* data, size_t len);
+    void base_connection_callback(BaseOFConnection* c, BaseOFConnection::Event event_type);
+    static void* send_echo(void* arg);
+};

--- a/fluid/OFServerSettings.cc
+++ b/fluid/OFServerSettings.cc
@@ -12,6 +12,12 @@ OFServerSettings::OFServerSettings() {
     this->dispatch_all_messages(false);
     this->use_hello_elements(false);
     this->keep_data_ownership(true);
+    this->is_controller(true);
+    this->datapath_id(0);
+    this->auxiliary_id(0);
+    this->n_buffers(0);
+    this->n_tables(0);
+    this->capabilities(0);
 }
 
 OFServerSettings& OFServerSettings::supported_version(const uint8_t version) {
@@ -39,7 +45,7 @@ void OFServerSettings::add_version(const uint8_t version) {
 uint32_t* OFServerSettings::supported_versions() {
     // We return a pointer because an OFServerSettings object is supposed to
     // be exclusively user by an OFServer instance which has a copy of it.
-    
+
     // TODO: since this->_supported_versions is just an uint32_t, we can only
     // support OpenFlow versions lower than 31. It might be a problem some day,
     // so it would be nice to change the implementation to a proper uint32_t
@@ -103,6 +109,60 @@ bool OFServerSettings::keep_data_ownership() {
 OFServerSettings& OFServerSettings::keep_data_ownership(const bool keep_data_ownership) {
     this->_keep_data_ownership = keep_data_ownership;
     return *this;
+}
+
+bool OFServerSettings::is_controller() {
+    return this->_is_controller;
+}
+
+OFServerSettings& OFServerSettings::is_controller(const bool is_controller) {
+    this->_is_controller = is_controller;
+    return *this;
+}
+
+OFServerSettings& OFServerSettings::datapath_id(const uint64_t di) {
+    this->_datapath_id = di;
+    return *this;
+}
+
+uint64_t OFServerSettings::datapath_id() {
+    return this->_datapath_id;
+}
+
+OFServerSettings& OFServerSettings::n_buffers(const uint32_t nb) {
+    this->_n_buffers = nb;
+    return *this;
+}
+
+uint32_t OFServerSettings::n_buffers() {
+    return this->_n_buffers;
+}
+
+OFServerSettings& OFServerSettings::n_tables(const uint8_t nt) {
+    this->_n_tables = nt;
+    return *this;
+}
+
+uint8_t OFServerSettings::n_tables() {
+    return this->_n_tables;
+}
+
+OFServerSettings& OFServerSettings::auxiliary_id(const uint8_t ai) {
+    this->_auxiliary_id = ai;
+    return *this;
+}
+
+uint8_t OFServerSettings::auxiliary_id() {
+    return this->_auxiliary_id;
+}
+
+OFServerSettings& OFServerSettings::capabilities(const uint32_t ca) {
+    this->_capabilities = ca;
+    return *this;
+}
+
+uint32_t OFServerSettings::capabilities() {
+    return this->_capabilities;
 }
 
 }

--- a/fluid/OFServerSettings.hh
+++ b/fluid/OFServerSettings.hh
@@ -28,7 +28,16 @@ public:
     - `dispatch_all_messages`: `false`
     - `use_hello_elems`: `false` (to avoid compatibility issues with
        existing software and hardware)
-    - `keep_data_ownership`: `true` (to simplify things)       
+    - `keep_data_ownership`: `true` (to simplify things)
+    - `is_controller`: `true` (OpenFlow controller is normally TCP server, when
+       set to false (to indicate OpenFlow switch), the following items must be
+       configured to ensure correct values in the features reply message)
+    - `datapath_id`: `0`
+    - `n_buffers`: `0`
+    - `n_tables`: `0`
+    - `auxiliary_id`: `0`
+    - `capabilities`: `0`
+
     */
     OFServerSettings();
 
@@ -128,12 +137,12 @@ public:
     Set whether the OFServer instance should own and manage the message data
     passed to its message callback (true) or if your application should be
     responsible for it (false).
-    
+
     See OFServerSettings::OFServerSettings for more details.
 
     @param keep_data_ownership true if OFServer is responsible for managing
                                message data, false if your application is.
-                               
+
     */
     OFServerSettings& keep_data_ownership(const bool keep_data_ownership);
 
@@ -142,7 +151,100 @@ public:
     your application (false).
     */
     bool keep_data_ownership();
-    
+
+    /**
+    Set whether the OFServer instance represents an OpenFlow controller. This affects
+    the initial handshake, a controller will send OFPT_FEATURES_REQUEST whereas
+    a switch will respond to such a request with OFPT_FEATURES_REPLY. The OpenFlow
+    specification includes this pertinent paragraph about TCP server/client role
+    reversal:
+       Optionally, the switch may allow the controller to initiate the connection.
+       In this case, the switch should accept incoming standard TLS or TCP connections
+       from the controller, using either a user-specified transport port or the default
+       OpenFlow transport port 6653 . Connections initiated by the switch and the
+       controller behave the same once the transport connection is established
+
+    See OFServerSettings::OFServerSettings for more details.
+
+    @param is_controller true for OpenFlow controller, false for OpenFlow switch.
+    */
+    OFServerSettings& is_controller(const bool is_controller);
+
+    /**
+    Return true if instance represents an OpenFlow controller, false for switch.
+    */
+    bool is_controller();
+
+    /**
+    Set the OpenFlow datapath ID. This is relevant for an OpenFlow switch (i.e.
+    when is_controller is false), and is needed in the OFPT_FEATURES_REPLY
+    message.
+
+    @param datapath_id the datapath ID.
+    */
+    OFServerSettings& datapath_id(const uint64_t datapath_id);
+
+    /**
+    Return the datapath ID.
+    */
+    uint64_t datapath_id();
+
+    /**
+    Set the switch supported n_buffers. This is relevant for an OpenFlow switch (i.e.
+    when is_controller is false), and is needed in the OFPT_FEATURES_REPLY
+    message.
+
+    @param n_buffers the number of buffers.
+    */
+    OFServerSettings& n_buffers(const uint32_t n_buffers);
+
+    /**
+    Return the number of buffers.
+    */
+    uint32_t n_buffers();
+
+    /**
+    Set the switch supported n_tables. This is relevant for an OpenFlow switch (i.e.
+    when is_controller is false), and is needed in the OFPT_FEATURES_REPLY
+    message.
+
+    @param n_tables the number of tables.
+    */
+    OFServerSettings& n_tables(const uint8_t n_tables);
+
+    /**
+    Return the number of tables.
+    */
+    uint8_t n_tables();
+
+    /**
+    Set the switch auxiliary ID. This is relevant for an OpenFlow switch (i.e.
+    when is_controller is false), and is needed in the OFPT_FEATURES_REPLY
+    message.
+
+    @param aux_id the auxiliary ID.
+    */
+    OFServerSettings& auxiliary_id(const uint8_t aux_id);
+
+    /**
+    Return the auxiliary ID.
+    */
+    uint8_t auxiliary_id();
+
+    /**
+    Set the switch capabilities bitmap. This is relevant for an OpenFlow switch (i.e.
+    when is_controller is false), and is needed in the OFPT_FEATURES_REPLY
+    message.
+
+    @param capabilities the capabilities bitmap.
+    */
+    OFServerSettings& capabilities(const uint32_t capabilities);
+
+    /**
+    Return the capabilities bitmap.
+    */
+    uint32_t capabilities();
+
     private:
         friend class OFServer;
 
@@ -158,6 +260,12 @@ public:
         bool _dispatch_all_messages;
         bool _use_hello_elements;
         bool _keep_data_ownership;
+        bool _is_controller;
+        uint64_t _datapath_id;
+        uint32_t _n_buffers;
+        uint8_t _n_tables;
+        uint8_t _auxiliary_id;
+        uint32_t _capabilities;
 };
 
 }

--- a/fluid/base/BaseOFClient.cc
+++ b/fluid/base/BaseOFClient.cc
@@ -1,0 +1,98 @@
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+#include <pthread.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include <event2/thread.h>
+
+#include "BaseOFClient.hh"
+
+using namespace fluid_base;
+
+BaseOFClient::BaseOFClient(int id, std::string address, int port) {
+    // Prepare libevent for threads
+    // This will leave a small, insignificant leak for us.
+    // See: http://archives.seul.org/libevent/users/Jul-2011/msg00028.html
+    evthread_use_pthreads();
+    // Ignore SIGPIPE so it becomes an EPIPE
+    signal(SIGPIPE, SIG_IGN);
+
+    this->id = id;
+    this->address = address;
+    this->port = port;
+    this->evloop = new EventLoop(0);
+}
+
+BaseOFClient::~BaseOFClient() {
+    delete this->evloop;
+}
+
+void* BaseOFClient::try_connect(void *arg){
+    int sock;
+    struct sockaddr_in echoserver;
+    int received = 0;
+
+    BaseOFClient *boc = (BaseOFClient*) arg;
+
+    /* Create the TCP socket */
+    if ((sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+        fprintf(stderr, "Error creating socket");
+        return NULL;
+    }
+    memset(&echoserver, 0, sizeof(echoserver));
+    echoserver.sin_family = AF_INET;
+    echoserver.sin_addr.s_addr = inet_addr(boc->address.c_str());
+    echoserver.sin_port = htons(boc->port);
+    while (connect(sock, (struct sockaddr *) &echoserver, sizeof(echoserver)) < 0) {
+        fprintf(stderr, "Retrying in 5 seconds...\n");
+        sleep(5);
+    }
+    BaseOFConnection* c = new BaseOFConnection(0,
+                                               boc,
+                                               boc->evloop,
+                                               sock,
+                                               false);
+    return NULL;
+}
+
+void BaseOFClient::start_conn(){
+    pthread_create(&conn_t, NULL,
+                      try_connect,
+                       this);
+}
+
+bool BaseOFClient::start(bool block) {
+    this->blocking = block;
+    start_conn();
+    if (not this->blocking) {
+        pthread_create(&t,
+                       NULL,
+                       EventLoop::thread_adapter,
+                       evloop);
+    }
+    else {
+        evloop->run();
+    }
+    return true;
+}
+
+void BaseOFClient::free_data(void* data) {
+    BaseOFConnection::free_data(data);
+}
+
+void BaseOFClient::stop() {
+    pthread_cancel(this->conn_t);
+    evloop->stop();
+    if (not this->blocking) {
+        pthread_join(t, NULL);
+    }
+}
+
+void BaseOFClient::base_connection_callback(BaseOFConnection* conn, BaseOFConnection::Event event_type) {
+    if (event_type == BaseOFConnection::EVENT_CLOSED) {
+        delete conn;
+    }
+}
+

--- a/fluid/base/BaseOFClient.hh
+++ b/fluid/base/BaseOFClient.hh
@@ -1,0 +1,74 @@
+/** @file */
+#ifndef __BASEOFCLIENT_HH__
+#define __BASEOFCLIENT_HH__
+
+#include <pthread.h>
+
+#include <string>
+
+#include <fluid/base/EventLoop.hh>
+#include <fluid/base/BaseOFConnection.hh>
+
+using namespace fluid_base;
+/**
+A BaseOFClient manages the very basic functions of an OpenFlow client. It
+connects to a server and wait for messages and connection events. It is an
+abstract class that should be overriden by another class to provide OpenFlow
+features.
+*/
+class BaseOFClient : public BaseOFHandler {
+public:
+    /**
+    Create a BaseOFClient.
+
+    @param port listen port
+    @param nevloops number of event loops to run. Connections will be
+                    attributed to event loops running on threads on a
+                    round-robin fashion. The first event loop will listen for
+                    new connections.
+    */
+    BaseOFClient(int id, std::string address, int port);
+    ~BaseOFClient();
+
+    /**
+    Start the client. It will connect at the address and port declared in the
+    constructor and wait for events, optionally blocking the calling thread
+    until BaseOFClient::stop is called.
+
+    @param block block the calling thread while the client is running
+    */
+    virtual bool start(bool block = false);
+
+    virtual void start_conn();
+
+    static void* try_connect(void* arg);
+
+    /**
+    Stop the client. It will close the connection and signal the event loop to
+    stop running.
+
+    It will eventually unblock BaseOFClient::start if it is blocking.
+    */
+    virtual void stop();
+
+
+    virtual void base_connection_callback(BaseOFConnection* conn,
+                                          BaseOFConnection::Event event_type);
+    virtual void base_message_callback(BaseOFConnection* conn,
+                                       void* data,
+                                       size_t len) = 0;
+    virtual void free_data(void* data);
+
+private:
+    int id;
+    bool blocking;
+    EventLoop* evloop;
+    pthread_t t;
+    pthread_t conn_t;
+
+    std::string address;
+    int port;
+
+};
+
+#endif

--- a/fluid/base/of.hh
+++ b/fluid/base/of.hh
@@ -144,4 +144,17 @@ struct ofp_error_msg {
 };
 OFP_ASSERT(sizeof(struct ofp_error_msg) == 12);
 
+/* OFPT_FEATURES_REPLY: Reply to features request message (switch -> controller). */
+struct ofp_switch_features {
+    struct ofp_header header;
+    uint64_t datapath_id;
+    uint32_t n_buffers;
+    uint8_t n_tables;
+    uint8_t auxiliary_id;
+    uint8_t pad[2];
+    uint32_t capabilities;
+    uint32_t reserved;
+};
+OFP_ASSERT(sizeof(struct ofp_switch_features) == 32);
+
 #endif


### PR DESCRIPTION
Add OFClient to libfluid_base. …
This initial version is copied directly from the libfluid bundle repository,
from examples/switch/client/ directory. Once it is embedded in
libfluid_base, we can make additional improvements more easily.

Expand OFClient, make controller/switch independent of client/server. …
- Move OFClient into fluid_base namespace
- Move OFClient implementation from .hh to .cc, add some comments in .hh
- Remove dependency on libfluid_msg that was present in OFClient
- In both OFClient and OFServer: send FEATURES_REQUEST after HELLO received if controller, or respond to FEATURES_REQUEST with FEATURES_REPLY if switch
- Add members to represent FEATURES_REPLY items in OFServerSettings class (OFServerSettings class now used by OFClient too, so bit of a misnomer)
- Add struct ofp_switch_features to of.hh to facilitate the FEATURES_REPLY message

Note: the main motivation for making controller/switch independent from client/server is the following paragraph from the OpenFlow specification:
  Optionally, the switch may allow the controller to initiate the connection.
  In this case, the switch should accept incoming standard TLS or TCP connections
  from the controller, using either a user-specified transport port or the default
  OpenFlow transport port 6653 . Connections initiated by the switch and the
  controller behave the same once the transport connection is established.

The secondary motivation is to allow OFClient to connect as a controller to an Open vSwitch instance which has been configured with a 'ptcp:6653' setting (see manpage for ovs-vsctl, under 'OpenFlow Controller Connectivity' section).
