### PR TITLE
Fix OpenFlow version negotiation

### DIFF
--- a/fluid/OFServer.cc
+++ b/fluid/OFServer.cc
@@ -178,7 +178,8 @@ void OFServer::base_message_callback(BaseOFConnection* c, void* data, size_t len
     }
 
     // Handle version negotiation failing
-    if (ofsc.handshake() and type == OFPT_ERROR) {
+    if (ofsc.handshake() and cc->get_state() == OFConnection::STATE_HANDSHAKE
+          and type == OFPT_ERROR) {
         cc->close();
         cc->set_state(OFConnection::STATE_FAILED);
         connection_callback(cc, OFConnection::EVENT_FAILED_NEGOTIATION);


### PR DESCRIPTION
The maximum version reported by the switch was always being used,
as a result if the libfluid application did not support this
version the negotiation would fail.

E.g. A switch supporting 1.0,1.3 and a controller supporting only 1.0
would fail rather than selecting version 1.0.

Now the highest version supported by both switch and controller is
selected as per the OpenFlow standard.
