### PR TITLE
Add ability to inject external events into the event loop

### DIFF
--- a/fluid/OFConnection.cc
+++ b/fluid/OFConnection.cc
@@ -58,7 +58,7 @@ void OFConnection::add_timed_callback(void* (*cb)(void*),
         this->conn->add_timed_callback(cb, interval, arg);
 }
 
-void OFConnection::add_immediate_event(void* (*cb)(void*), void* arg) {
+void OFConnection::add_immediate_event(void* (*cb)(std::shared_ptr<void>), std::shared_ptr<void> arg) {
     if (this->conn != NULL) {
         this->conn->add_immediate_event(cb, arg);
     }

--- a/fluid/OFConnection.cc
+++ b/fluid/OFConnection.cc
@@ -58,6 +58,12 @@ void OFConnection::add_timed_callback(void* (*cb)(void*),
         this->conn->add_timed_callback(cb, interval, arg);
 }
 
+void OFConnection::add_immediate_event(void* (*cb)(void*), void* arg) {
+    if (this->conn != NULL) {
+        this->conn->add_immediate_event(cb, arg);
+    }
+}
+
 void* OFConnection::get_application_data() {
     return this->application_data;
 }

--- a/fluid/OFConnection.hh
+++ b/fluid/OFConnection.hh
@@ -129,6 +129,19 @@ public:
     void add_timed_callback(void* (*cb)(void*), int interval, void* arg);
     // TODO: add the option for the function to unschedule itself by returning
     // false
+   
+    /**
+    Set up a function to be called immediately in the event loop. This can be
+    used to add events from an external source (i.e. not OVS) in a thread-safe
+    manner.
+
+    This method is thread-safe.
+
+    @param cb the callback function. It should accept a void* argument and
+              return a void*.
+    @param arg an argument to the callback function
+    */
+    void add_immediate_event(void* (*cb)(void*), void* arg);
 
     /**
     Get application data. This data is any piece of data you might want to 

--- a/fluid/OFConnection.hh
+++ b/fluid/OFConnection.hh
@@ -137,11 +137,11 @@ public:
 
     This method is thread-safe.
 
-    @param cb the callback function. It should accept a void* argument and
+    @param cb the callback function. It should accept a shared_ptr  argument and
               return a void*.
     @param arg an argument to the callback function
     */
-    void add_immediate_event(void* (*cb)(void*), void* arg);
+    void add_immediate_event(void* (*cb)(std::shared_ptr<void>), std::shared_ptr<void> arg);
 
     /**
     Get application data. This data is any piece of data you might want to 

--- a/fluid/base/BaseOFConnection.cc
+++ b/fluid/base/BaseOFConnection.cc
@@ -236,6 +236,21 @@ void BaseOFConnection::add_timed_callback(void* (*cb)(void*), int interval, void
     event_add(ev, &tv);
 }
 
+void BaseOFConnection::add_immediate_event(void* (*cb)(void*), void* arg) {
+    struct timed_callback* tc = new struct timed_callback;
+    tc->cb = cb;
+    tc->cb_arg = arg;
+    struct event_base* base = (struct event_base*) this->evloop->get_base();
+    // add timeout event with NULL timeval, which adds the event immediately
+    // to the event loop
+    event_base_once(base,
+                    -1,
+                    EV_TIMEOUT,
+                    BaseOFConnection::LibEventBaseOFConnection::timer_callback,
+                    tc,
+                    NULL); // timeout
+}
+
 void BaseOFConnection::set_manager(void* manager) {
     this->manager = manager;
 }

--- a/fluid/base/BaseOFConnection.hh
+++ b/fluid/base/BaseOFConnection.hh
@@ -74,6 +74,19 @@ public:
     // TODO: add the option for the function to unschedule itself by returning
     // false
 
+    /**
+    Set up a function to be called immediately in the event loop. This can be
+    used to add events from an external source (i.e. not OVS) in a thread-safe
+    manner.
+
+    This method is thread-safe.
+
+    @param cb the callback function. It should accept a void* argument and
+              return a void*.
+    @param arg an argument to the callback function
+    */
+    void add_immediate_event(void* (*cb)(void*), void* arg);
+
     // TODO: these methods are not thread-safe, and they really aren't
     // currently called from more than one thread. But perhaps we should
     // consider that...

--- a/fluid/base/BaseOFConnection.hh
+++ b/fluid/base/BaseOFConnection.hh
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <vector>
+#include <memory>
 
 #include "fluid/base/EventLoop.hh"
 
@@ -81,11 +82,11 @@ public:
 
     This method is thread-safe.
 
-    @param cb the callback function. It should accept a void* argument and
+    @param cb the callback function. It should accept a shared_ptr argument and
               return a void*.
     @param arg an argument to the callback function
     */
-    void add_immediate_event(void* (*cb)(void*), void* arg);
+    void add_immediate_event(void* (*cb)(std::shared_ptr<void>), std::shared_ptr<void> arg);
 
     // TODO: these methods are not thread-safe, and they really aren't
     // currently called from more than one thread. But perhaps we should
@@ -150,6 +151,11 @@ private:
         void* (*cb)(void*);
         void* cb_arg;
         void* data;
+    };
+
+    struct immediate_callback {
+        void* (*cb)(std::shared_ptr<void>);
+	std::shared_ptr<void> cb_arg;
     };
     std::vector<struct timed_callback*> timed_callbacks;
 


### PR DESCRIPTION
Currently, there was a way to add periodic events to the event loop, but no way to add a one time event to the loop. This is useful when there are external triggers to add/delete flows to the switch. This revision adds the ability to add a one-time event to be processed immediately in the event loop thread. 